### PR TITLE
Fix/babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,9 +5,7 @@ module.exports = api => {
       [
         '@babel/preset-env',
         {
-          targets: {
-            node: 10,
-          },
+          targets: '> 0.25%, not dead',
         },
       ],
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@epsor/apollo-client-wrapper",
-	"version": "2.2.1",
+	"version": "2.2.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epsor/apollo-client-wrapper",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": "Epsor",
   "description": "GraphQL API Client for Epsor",
   "main": "dist/index.js",


### PR DESCRIPTION
Targetter NodeJS dans un paquet client, ça n'a pas trop de sens.

MS Edge pète à cause de ça car Babel ne transforme pas certains destructuring d'objets.

#### Technical checklist

- [x] I tested my code following testing cases.
- [x] I covered my code with automatic tests.
- [x] I added logs in case of error or business logic.
- [x] I well designed my commits.
- [x] I read my Pull Request's changes.
- [x] I respected provided design and wording.
